### PR TITLE
-feat Supplement the missing getVolumeViewport method

### DIFF
--- a/packages/core/src/RenderingEngine/RenderingEngine.ts
+++ b/packages/core/src/RenderingEngine/RenderingEngine.ts
@@ -421,6 +421,34 @@ class RenderingEngine {
     return viewports.filter(isVolumeViewport) as IVolumeViewport[];
   }
 
+/**
+ * Retrieves a volume viewport by its ID. used just for type safety
+ *
+ * @param viewportId - The ID of the viewport to retrieve.
+ * @returns The volume viewport with the specified ID.
+ * @throws Error if the viewport with the given ID does not exist or is not a StackViewport.
+*/
+  public getVolumeViewport(viewportId:string): IVolumeViewport {
+    this._throwIfDestroyed();
+
+    const viewports = this.getViewports();
+
+    const isVolumeViewport = (
+      viewport: IViewport
+    ): viewport is BaseVolumeViewport => {
+      return viewport instanceof BaseVolumeViewport;
+    };
+
+    const VolumeViewportList = viewports.filter(isVolumeViewport) as IVolumeViewport[];
+
+    const volumeViewport = VolumeViewportList.find(viewport =>viewportId === viewport.id)
+
+    if(!volumeViewport){
+       throw new Error(`Viewport with Id ${viewportId} does not exist`);
+    }
+    return volumeViewport;
+  }
+
   /**
    * Renders all viewports on the next animation frame.
    *


### PR DESCRIPTION

<!-- Do Not Delete This! pr_template -->
<!-- Please read our Rules of Conduct: https://github.com/OHIF/Viewers/blob/master/CODE_OF_CONDUCT.md -->
<!-- :hand: Thank you for starting this amazing contribution! -->

<!--
⚠️⚠️ Please make sure the checklist section below is complete before submitting your PR.
To complete the checklist, add an 'x' to each item: [] -> [x]
(PRs that do not have all the checkboxes marked will not be approved)
-->

### Context

<!--
Provide a clear explanation of the reasoning behind this change, such as:
- A link to the issue being addressed, using the format "Fixes #ISSUE_NUMBER"
- An image showing the issue or problem being addressed (if not already in the issue)
- Error logs or callStacks to help with the understanding of the problem (if not already in the issue)
-->

It can cause 'renderEngine' to encounter inconsistent behavior with other methods when obtaining a separate 'volumeViewport', such as' getViewport/getViewports' or 'getStackViewport/getStackViewports'. Due to habit, users may try to use' getVolumeViewport 'but find that it does not exist. Therefore, we would like to supplement the implementation of this method

### Changes & Results

<!--
List all the changes that have been done, such as:
- Add new components
- Remove old components
- Update dependencies

What are the effects of this change?
- Before vs After
- Screenshots / GIFs / Videos
-->

Supplement the missing getVolumeViewport method
![image](https://github.com/user-attachments/assets/503abc4c-4d5d-4026-85a6-e8e35d6a91be)


### Testing

<!--
Describe how we can test your changes.
- open a URL
- visit a page
- click on a button
- etc.
-->

look file:
/packages/core/src/RenderingEngine/RenderingEngine.ts

### Checklist

#### PR

<!--
https://semantic-release.gitbook.io/semantic-release/#how-does-it-work

Examples:
Please note the letter casing in the provided examples (upper or lower).

- feat(MeasurementService): add ...
- fix(Toolbar): fix ...
- docs(Readme): update ...
- style(Whitespace): fix ...
- refactor(ExtensionManager): ...
- test(HangingProtocol): Add test ...
- chore(git): update ...
- perf(VolumeLoader): ...

You don't need to have each commit within the Pull Request follow the rule,
but the PR title must comply with it, as it will be used as the commit message
after the commits are squashed.
-->

- [] My Pull Request title is descriptive, accurate and follows the
  semantic-release format and guidelines.

#### Code

- [] My code has been well-documented (function documentation, inline comments,
  etc.)



#### Public Documentation Updates

<!-- https://cornerstonejs.org/ -->

- [] The documentation page has been updated as necessary for any public API
  additions or removals.

#### Tested Environment

- [] "OS: <!--[e.g. Windows 10, macOS 10.15.4]"-->
- [] "Node version: <!--[e.g. 16.14.0]"-->
- [] "Browser:
  <!--[e.g. Chrome 83.0.4103.116, Firefox 77.0.1, Safari 13.1.1]"-->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->
